### PR TITLE
[Chore] Pin dependency color-convert to version 1.9.0

### DIFF
--- a/node_modules/ansi-styles/package.json
+++ b/node_modules/ansi-styles/package.json
@@ -46,7 +46,7 @@
     "url": "https://github.com/chalk/ansi-styles/issues"
   },
   "dependencies": {
-    "color-convert": "^1.0.0"
+    "color-convert": "1.9.0"
   },
   "description": "ANSI escape codes for styling strings in the terminal",
   "devDependencies": {


### PR DESCRIPTION
This Pull Request update dependency color-convert from version ^1.0.0 to 1.9.0

