### PR TITLE
[Chore] Pin dependency events to version 1.1.1

### DIFF
--- a/node_modules/asap/package.json
+++ b/node_modules/asap/package.json
@@ -44,7 +44,7 @@
   "dependencies": {},
   "description": "High-priority task queue for Node.js and browsers",
   "devDependencies": {
-    "events": "^1.0.1",
+    "events": "1.1.1",
     "jshint": "^2.5.1",
     "knox": "^0.8.10",
     "mr": "^2.0.5",


### PR DESCRIPTION
This Pull Request update dependency events from version ^1.0.1 to 1.1.1

