### PR TITLE
[Chore] Pin dependency jshint to version 2.9.4

### DIFF
--- a/node_modules/asap/package.json
+++ b/node_modules/asap/package.json
@@ -45,7 +45,7 @@
   "description": "High-priority task queue for Node.js and browsers",
   "devDependencies": {
     "events": "^1.0.1",
-    "jshint": "^2.5.1",
+    "jshint": "2.9.4",
     "knox": "^0.8.10",
     "mr": "^2.0.5",
     "opener": "^1.3.0",


### PR DESCRIPTION
This Pull Request update dependency jshint from version ^2.5.1 to 2.9.4

