### PR TITLE
[Chore] Pin dependency weak-map to version 1.0.5

### DIFF
--- a/node_modules/asap/package.json
+++ b/node_modules/asap/package.json
@@ -53,7 +53,7 @@
     "q-io": "^2.0.3",
     "saucelabs": "^0.1.1",
     "wd": "^0.2.21",
-    "weak-map": "^1.0.5"
+    "weak-map": "1.0.5"
   },
   "directories": {},
   "dist": {


### PR DESCRIPTION
This Pull Request update dependency weak-map from version ^1.0.5 to 1.0.5

